### PR TITLE
naive PGO implementation

### DIFF
--- a/engine/Makefile
+++ b/engine/Makefile
@@ -27,6 +27,21 @@ endif
 
 OUT := $(EXE)$(SUFFIX)
 
+.PHONY : clean build pgo-build
 
-$(EXE): $(SOURCES)
+build: $(SOURCES)
 	$(CXX) $^ $(CXXFLAGS) -o $(OUT) $(LINKER) 
+
+default: 
+	build
+
+clean : 
+	rm $(OUT)
+
+pgo-build: $(SOURCES)
+	$(CXX) $^ $(CXXFLAGS) -o $(OUT) $(LINKER) -fprofile-generate=patricia.profraw
+	./$(OUT) bench
+	llvm-profdata merge patricia.profraw -o patricia.profdata
+	$(CXX) $^ $(CXXFLAGS) -o $(OUT) $(LINKER) -fprofile-use=patricia.profdata
+	rm -rf patricia.profraw patricia.profdata
+


### PR DESCRIPTION
A naive PGO implementation. Needs benchmarking. One possible problem is that bench doesn't provide full code coverage of all of search.(checked with llvm-cov)