### PR TITLE
Fix missing include.

### DIFF
--- a/engine/src/defs.h
+++ b/engine/src/defs.h
@@ -1,7 +1,9 @@
 #pragma once
+#include <array>
 #include <chrono>
 #include <cinttypes>
 #include <cstdint>
+
 
 namespace Colors {
 constexpr uint8_t White = 0;

--- a/engine/src/defs.h
+++ b/engine/src/defs.h
@@ -4,7 +4,6 @@
 #include <cinttypes>
 #include <cstdint>
 
-
 namespace Colors {
 constexpr uint8_t White = 0;
 constexpr uint8_t Black = 1;


### PR DESCRIPTION
Fix missing array include. For some reason this works without the include on mingw, even though I don't think it should. Doesn't work on native windows compile.