### PR TITLE
Disable nodes limit unless specified again

### DIFF
--- a/engine/src/uci.h
+++ b/engine/src/uci.h
@@ -200,6 +200,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
       if (s.joinable()) {
         s.join();
       }
+      thread_info.max_nodes_searched = UINT64_MAX / 2;
       thread_info.max_iter_depth = MaxSearchDepth;
 
       int color = position.color, time = INT32_MAX, increment = 0;


### PR DESCRIPTION
Until now, there was a bug that by running "go nodes x" and then "go depth 20", the nodes limit would remain

Bench 5602795