### PR TITLE
reduce sbeta margin

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -623,7 +623,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
           abs(entry.score) < MateScore && entry.depth >= depth - 3 &&
           entry_type != EntryTypes::UBound) {
 
-        int sBeta = entry.score - depth * 3;
+        int sBeta = entry.score - depth;
         thread_info.excluded_move = move;
         int sScore = search(sBeta - 1, sBeta, (depth - 1) / 2, cutnode,
                             position, thread_info, TT);


### PR DESCRIPTION
Elo   | 7.01 +- 3.59 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=128MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 10316 W: 2825 L: 2617 D: 4874
Penta | [71, 1102, 2593, 1332, 60]
https://chess.swehosting.se/test/8049/

Bench: 7498607