### PR TITLE
bestmove stability

### DIFF
--- a/engine/src/tm.h
+++ b/engine/src/tm.h
@@ -2,9 +2,11 @@
 #include "defs.h"
 #include "utils.h"
 
-void adjust_soft_limit(ThreadInfo &thread_info, uint64_t best_move_nodes) {
+void adjust_soft_limit(ThreadInfo &thread_info, uint64_t best_move_nodes, int bm_stability) {
   double fract = (double)best_move_nodes / thread_info.nodes;
   double factor = (1.5 - fract) * 1.75;
-  thread_info.opt_time = std::min<uint32_t>(thread_info.original_opt * factor,
+  double bm_factor = 1.5 - (bm_stability * 0.06);
+
+  thread_info.opt_time = std::min<uint32_t>(thread_info.original_opt * factor * bm_factor,
                                             thread_info.max_time);
 }


### PR DESCRIPTION
Bench: 7341237
Elo   | 4.23 +- 2.72 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 20138 W: 5635 L: 5390 D: 9113
Penta | [230, 2161, 5083, 2324, 271]
https://chess.swehosting.se/test/8110/