### PR TITLE
reset next killer at start of moveloop

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -543,6 +543,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
   int num_quiets = 0;
   Move captures[64];
   int num_captures = 0;
+  thread_info.KillerMoves[ply + 1] = MoveNone;
 
   MoveInfo moves;
   int num_moves = movegen(position, moves.moves, in_check),


### PR DESCRIPTION
Bench: 6795207

Elo   | 4.31 +- 2.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 20872 W: 5899 L: 5640 D: 9333
Penta | [298, 2348, 4926, 2525, 339]
https://chess.swehosting.se/test/8157/