### PR TITLE
return average of eval and beta in rfp

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -510,7 +510,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
     if (depth <= RFPMaxDepth &&
         static_eval - RFPMargin * (depth - improving) >= beta) {
-      return static_eval;
+      return (static_eval + beta) / 2;
     }
     if (static_eval >= beta && depth >= NMPMinDepth &&
         has_non_pawn_material(position, color) &&


### PR DESCRIPTION
Bench: 5813201

Elo   | 6.61 +- 3.64 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 12358 W: 3495 L: 3260 D: 5603
Penta | [164, 1380, 2882, 1563, 190]
https://chess.swehosting.se/test/8388/