### PR TITLE
reduce depth on fail high

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -926,7 +926,7 @@ void iterative_deepen(
          thread_info.multipv_index < real_multi_pv;
          thread_info.multipv_index++) {
 
-      // std::cout << i << " " << thread_info.multipv_index << std::endl;
+      int temp_depth = depth;
 
       int score, delta = 20;
 
@@ -971,13 +971,15 @@ void iterative_deepen(
         if (score <= alpha) {
           beta = (alpha + beta) / 2;
           alpha -= delta;
+          temp_depth = depth;
         } else if (score >= beta) {
           beta += delta;
+          temp_depth = std::max(temp_depth - 1, 1);
         }
         delta += delta / 3;
-
+        
         score =
-            search<true>(alpha, beta, depth, false, position, thread_info, TT);
+            search<true>(alpha, beta, temp_depth, false, position, thread_info, TT);
       }
 
       if (score == ScoreNone) {


### PR DESCRIPTION
Bench: 5375006

Elo   | 5.29 +- 3.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 3.00]
Games | N: 17740 W: 5241 L: 4971 D: 7528
Penta | [353, 1987, 3963, 2171, 396]
https://chess.swehosting.se/test/8484/