### PR TITLE
history pruning

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -618,6 +618,9 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
     uint64_t curr_nodes = thread_info.nodes;
 
+    int hist_score = thread_info.HistoryScores[position.board[extract_from(move)]]
+                                      [extract_to(move)];
+
     is_capture = is_cap(position, move);
     if (!is_capture && !is_pv && best_score > -MateScore) {
 
@@ -634,6 +637,10 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       if (!in_check && depth < FPDepth && move_score < GoodCaptureBaseScore &&
           static_eval + FPMargin1 + FPMargin2 * depth < alpha) {
+        skip = true;
+      }
+
+      if (!is_pv && !is_capture && depth < 4 && hist_score < -4096 * depth){
         skip = true;
       }
     }
@@ -707,8 +714,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
         // alpha/beta
         R /= 2;
       } else {
-        R -= thread_info.HistoryScores[position.board[extract_from(move)]]
-                                      [extract_to(move)] /
+        R -= hist_score /
              10000;
       }
 


### PR DESCRIPTION
Bench: 4606731

Elo   | 2.12 +- 1.68 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 53176 W: 10571 L: 10246 D: 32359
Penta | [593, 6031, 13048, 6290, 626]
https://chess.swehosting.se/test/9576/