### PR TITLE
do shallower

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -773,6 +773,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R += cutnode;
 
+
       // Clamp reduction so we don't immediately go into qsearch
       R = std::clamp(R, 0, depth - 1);
 
@@ -782,6 +783,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       if (score > alpha) {
         full_search = R > 1;
         newdepth += (score > (best_score + 60 + newdepth * 2));
+        newdepth -= (score < best_score + newdepth && !root);
       }
     } else {
       full_search = moves_played || !is_pv;


### PR DESCRIPTION
Bench: 4194283

Elo   | 8.95 +- 4.22 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 3.00]
Games | N: 8194 W: 1564 L: 1353 D: 5277
Penta | [72, 864, 2045, 1013, 103]
https://chess.swehosting.se/test/9914/