### PR TITLE
remove negative reductions

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -773,8 +773,6 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R += cutnode;
 
-      R -= (tt_hit && entry.depth > depth);
-
 
       // Clamp reduction so we don't immediately go into qsearch
       R = std::clamp(R, 1, newdepth - 1);

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -777,7 +777,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
 
       // Clamp reduction so we don't immediately go into qsearch
-      R = std::clamp(R, 0, depth - 1);
+      R = std::clamp(R, 1, newdepth - 1);
 
       // Reduced search, reduced window
       score = -search<false>(-alpha - 1, -alpha, newdepth - R + 1, true,

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -773,6 +773,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R += cutnode;
 
+      R -= (tt_hit && entry.depth > depth);
+
 
       // Clamp reduction so we don't immediately go into qsearch
       R = std::clamp(R, 0, depth - 1);


### PR DESCRIPTION
Elo   | 2.33 +- 1.79 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 43278 W: 7610 L: 7320 D: 28348
Penta | [393, 4724, 11158, 4928, 436]
https://chess.swehosting.se/test/9997/