### PR TITLE
ttdepth in lmr

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -769,6 +769,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       // Increase reduction if not in pv
       R -= is_pv;
 
+      R -= (tt_hit && entry.depth >= depth);
+
       // Increase reduction if not improving
       R += !improving;
 


### PR DESCRIPTION
Elo   | 3.84 +- 2.54 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 21652 W: 3917 L: 3678 D: 14057
Penta | [203, 2306, 5589, 2505, 223]
https://chess.swehosting.se/test/10259/