### PR TITLE
reduce reduction if move is a check

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -779,6 +779,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R += cutnode;
 
+      R -= (attacks_square(moved_position, get_king_pos(position, color ^ 1), color) != 0);
+
 
       // Clamp reduction so we don't immediately go into qsearch
       R = std::clamp(R, 0, newdepth - 1);


### PR DESCRIPTION
Bench: 4556505

Elo   | 2.36 +- 1.81 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 3.00]
Games | N: 42638 W: 7476 L: 7186 D: 27976
Penta | [418, 4562, 11099, 4792, 448]
https://chess.swehosting.se/test/10364/