### PR TITLE
increase reduction if lots of fail highs

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -636,6 +636,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
   Move captures[64];
   int num_captures = 0;
   thread_info.KillerMoves[ply + 1] = MoveNone;
+  thread_info.FailHighCount[ply + 2] = 0;
 
   MovePicker picker;
   init_picker(picker, position, -107, in_check, ss);
@@ -781,6 +782,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R -= (attacks_square(moved_position, get_king_pos(position, color ^ 1), color) != 0);
 
+      R += thread_info.FailHighCount[ply + 1] > 4;
+
 
       // Clamp reduction so we don't immediately go into qsearch
       R = std::clamp(R, 0, newdepth - 1);
@@ -862,6 +865,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
   }
 
   if (best_score >= beta) {
+
+    thread_info.FailHighCount[ply]++;
 
     int piece = position.board[extract_from(best_move)],
         sq = extract_to(best_move);
@@ -1031,6 +1036,7 @@ void iterative_deepen(
   thread_info.best_scores = {ScoreNone, ScoreNone, ScoreNone, ScoreNone,
                              ScoreNone};
   std::memset(&thread_info.KillerMoves, 0, sizeof(thread_info.KillerMoves));
+  std::memset(&thread_info.FailHighCount, 0, sizeof(thread_info.FailHighCount));
 
   // Prepare root moves
   thread_info.root_moves.reserve(ListSize);

--- a/engine/src/utils.h
+++ b/engine/src/utils.h
@@ -40,6 +40,7 @@ struct ThreadInfo {
   MultiArray<int16_t, 2, 16384> PawnCorrHist;
   MultiArray<int16_t, 2, 2, 16384> NonPawnCorrHist;
   std::array<Move, MaxSearchDepth + 1> KillerMoves;
+  std::array<int16_t, MaxSearchDepth + 1> FailHighCount;
 
   uint8_t current_iter;
   uint16_t multipv = 1;


### PR DESCRIPTION
Bench: 3285890

Elo   | 2.94 +- 2.11 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 3.00]
Games | N: 31110 W: 5478 L: 5215 D: 20417
Penta | [294, 3314, 8097, 3535, 315]
https://chess.swehosting.se/test/10488/