### PR TITLE
lmr depth

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -743,6 +743,8 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
     is_capture = is_cap(position, move);
     if (!is_capture && !is_pv && best_score > ScoreLost) {
 
+      int lmr_depth = std::max(1, depth - LMRTable[depth][moves_played]);
+
       // Late Move Pruning (LMP): If we've searched enough moves, we can skip
       // the rest.
 
@@ -755,7 +757,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       // a good capture, we can skip the rest.
 
       if (!in_check && depth < FPDepth && picker.stage > Stages::Captures &&
-          static_eval + FPMargin1 + FPMargin2 * depth < alpha) {
+          static_eval + FPMargin1 + FPMargin2 * lmr_depth < alpha) {
         skip = true;
       }
 
@@ -850,7 +852,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R -= (attacks_square(moved_position, get_king_pos(position, color ^ 1), color) != 0);
 
-      R += thread_info.FailHighCount[ply + 1] > 4;
+      R += (thread_info.FailHighCount[ply + 1] > 4);
 
 
       // Clamp reduction so we don't immediately go into qsearch


### PR DESCRIPTION
Bench: 3122573
Elo   | 1.80 +- 1.42 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.04 (-2.94, 2.94) [0.00, 3.00]
Games | N: 66766 W: 11515 L: 11170 D: 44081
Penta | [566, 7167, 17674, 7308, 668]
https://chess.swehosting.se/test/10974/