### PR TITLE
More lmrdepth

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -743,8 +743,6 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
     is_capture = is_cap(position, move);
     if (!is_capture && !is_pv && best_score > ScoreLost) {
 
-      int lmr_depth = std::max(1, depth - LMRTable[depth][moves_played]);
-
       // Late Move Pruning (LMP): If we've searched enough moves, we can skip
       // the rest.
 
@@ -757,7 +755,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       // a good capture, we can skip the rest.
 
       if (!in_check && depth < FPDepth && picker.stage > Stages::Captures &&
-          static_eval + FPMargin1 + FPMargin2 * lmr_depth < alpha) {
+          static_eval + FPMargin1 + FPMargin2 * depth < alpha) {
         skip = true;
       }
 
@@ -852,7 +850,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R -= (attacks_square(moved_position, get_king_pos(position, color ^ 1), color) != 0);
 
-      R += (thread_info.FailHighCount[ply + 1] > 4);
+      R += thread_info.FailHighCount[ply + 1] > 4;
 
 
       // Clamp reduction so we don't immediately go into qsearch

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -743,11 +743,13 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
     is_capture = is_cap(position, move);
     if (!is_capture && !is_pv && best_score > ScoreLost) {
 
+      int lmr_depth = std::max(1, depth - LMRTable[depth][moves_played]);
+
       // Late Move Pruning (LMP): If we've searched enough moves, we can skip
       // the rest.
 
       if (depth < LMPDepth &&
-          moves_played >= LMPBase + depth * depth / (2 - improving)) {
+          moves_played >= LMPBase + lmr_depth * lmr_depth / (2 - improving)) {
         skip = true;
       }
 
@@ -755,7 +757,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       // a good capture, we can skip the rest.
 
       if (!in_check && depth < FPDepth && picker.stage > Stages::Captures &&
-          static_eval + FPMargin1 + FPMargin2 * depth < alpha) {
+          static_eval + FPMargin1 + FPMargin2 * lmr_depth < alpha) {
         skip = true;
       }
 
@@ -850,7 +852,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
       R -= (attacks_square(moved_position, get_king_pos(position, color ^ 1), color) != 0);
 
-      R += thread_info.FailHighCount[ply + 1] > 4;
+      R += (thread_info.FailHighCount[ply + 1] > 4);
 
 
       // Clamp reduction so we don't immediately go into qsearch

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -749,7 +749,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
       // the rest.
 
       if (depth < LMPDepth &&
-          moves_played >= LMPBase + lmr_depth * lmr_depth / (2 - improving)) {
+          moves_played >= LMPBase + depth * depth / (2 - improving)) {
         skip = true;
       }
 
@@ -761,7 +761,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
         skip = true;
       }
 
-      if (!is_pv && !is_capture && depth < HistPruningDepth && hist_score < -4096 * depth) {
+      if (!is_pv && !is_capture && lmr_depth < HistPruningDepth && hist_score < -4096 * lmr_depth) {
         skip = true;
       }
     }


### PR DESCRIPTION
Elo   | 1.62 +- 1.29 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 3.00]
Games | N: 81350 W: 14124 L: 13745 D: 53481
Penta | [734, 8725, 21438, 8984, 794]
https://chess.swehosting.se/test/11008/