### PR TITLE
Qs tweak

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -365,6 +365,8 @@ int qsearch(int alpha, int beta, Position &position, ThreadInfo &thread_info,
   if (!is_cap(position, tt_move)) {
     tt_move = MoveNone;
   }
+  int moves_played = 0;
+  
   while (Move move =
              next_move(picker, position, thread_info, tt_move, !in_check)) {
 
@@ -374,8 +376,9 @@ int qsearch(int alpha, int beta, Position &position, ThreadInfo &thread_info,
     if (!is_legal(position, move)) {
       continue;
     }
-    if (!in_check && SEE(position, move, beta - static_eval + 100)){
-      return beta;
+    moves_played++;
+    if (moves_played > 2){
+      break;
     }
 
     Position moved_position = position;


### PR DESCRIPTION
Elo   | 2.18 +- 1.69 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 47570 W: 8371 L: 8073 D: 31126
Penta | [427, 5117, 12435, 5343, 463]
https://chess.swehosting.se/test/11324/

Bench 3296690