### PR TITLE
change opt time to use more time

### DIFF
--- a/engine/src/uci.h
+++ b/engine/src/uci.h
@@ -432,7 +432,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
 
       time = std::max(2, time - 50);
       thread_info.max_time = time / 2;
-      thread_info.opt_time = (time / 20 + increment * 8 / 10) * 6 / 10;
+      thread_info.opt_time = (time / 20 + increment) * 6 / 10;
 
     run:
       run_thread(position, thread_info, s);


### PR DESCRIPTION
Bench: 3296690

Elo   | 2.90 +- 2.07 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29384 W: 5245 L: 5000 D: 19139
Penta | [231, 2947, 8103, 3168, 243]
https://chess.swehosting.se/test/12006/