### PR TITLE
increase maximum time to 80% of remaining time

### DIFF
--- a/engine/src/uci.h
+++ b/engine/src/uci.h
@@ -431,7 +431,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
       // Calculate time allotted to search
 
       time = std::max(2, time - 50);
-      thread_info.max_time = time / 2;
+      thread_info.max_time = time * 8 / 10;
       thread_info.opt_time = (time / 20 + increment) * 6 / 10;
 
     run:


### PR DESCRIPTION
Bench: 3296690

Elo   | 2.31 +- 1.77 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 40604 W: 7234 L: 6964 D: 26406
Penta | [312, 4141, 11141, 4381, 327]
https://chess.swehosting.se/test/12036/