### PR TITLE
Razoring

### DIFF
--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -622,6 +622,13 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
   if (!is_pv && !in_check && !singular_search) {
 
+    if (alpha < 2000 && static_eval + 400 * depth < alpha){
+      score = qsearch(alpha, beta, position, thread_info, TT);
+      if (score <= alpha){
+        return score;
+      }
+    }
+
     // Reverse Futility Pruning (RFP): If our position is way better than beta,
     // we're likely good to stop searching the node.
 

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -622,7 +622,7 @@ int search(int alpha, int beta, int depth, bool cutnode, Position &position,
 
   if (!is_pv && !in_check && !singular_search) {
 
-    if (alpha < 2000 && static_eval + 400 * depth < alpha){
+    if (alpha < 2000 && depth < 5 && static_eval + 400 * depth < alpha){
       score = qsearch(alpha, beta, position, thread_info, TT);
       if (score <= alpha){
         return score;


### PR DESCRIPTION
Elo   | 1.56 +- 1.25 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 3.00]
Games | N: 89152 W: 15827 L: 15426 D: 57899
Penta | [858, 9739, 23007, 10088, 884]
https://chess.swehosting.se/test/12147/

Bench: 3293467