### PR TITLE
Add WebAssembly build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,30 @@ Patricia has support for data generation; in order to compile the datagen script
 
 ***
 
+## WebAssembly Build
+
+Patricia can be compiled to WebAssembly for use in browsers:
+
+```bash
+cd engine
+source /path/to/emsdk/emsdk_env.sh
+make wasm
+```
+
+This produces `patricia.js` and `patricia.wasm`. Use in JavaScript:
+
+```javascript
+Patricia().then(Module => {
+    Module.ccall('wasm_uci_command', null, ['string'], ['uci']);
+    Module.ccall('wasm_uci_command', null, ['string'], ['position startpos']);
+    Module.ccall('wasm_uci_command', null, ['string'], ['go depth 10']);
+});
+```
+
+Note: WASM build is single-threaded and does not support Syzygy tablebases.
+
+***
+
 ## Acknowledgements
 
 - A huge shoutout to Stefan Pohl. His EAS Tool works wonderfully, makes properly and objectively testing for increase aggression possible, and is the measure by which Patricia development progressed. He was also very invested in Patricia's development and explained many features of the EAS tool to me so that I had a better understanding of what was a sacrifice and what wasn't. He has put a lot of time into quantifying style, and I am happy to have Patricia be a proof-of-concept and culmination of his ideas.

--- a/engine/Makefile
+++ b/engine/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build datagen aarch64 cross-aarch64 cross-aarch64-clang
+.PHONY: build datagen aarch64 cross-aarch64 cross-aarch64-clang wasm
 
 EXE := patricia
 SOURCES := src/patricia.cpp src/fathom/src/tbprobe.c
@@ -50,3 +50,22 @@ cross-aarch64-clang: CXXFLAGS := --target=aarch64-linux-gnu -O3 -std=c++20 -ffas
 cross-aarch64-clang: OUT := $(EXE)_aarch64$(SUFFIX)
 cross-aarch64-clang: $(SOURCES)
 	$(CXX) $(CXXFLAGS) $^ -o $(OUT)
+
+# --- WebAssembly build (Emscripten) -----------------------------------------
+WASM_SOURCES := src/patricia.cpp
+wasm: CXX := em++
+wasm: CXXFLAGS := -O3 -std=c++20 -ffast-math \
+    -DWASM_BUILD \
+    -s WASM=1 \
+    -s MODULARIZE=1 \
+    -s EXPORT_NAME="Patricia" \
+    -s ALLOW_MEMORY_GROWTH=1 \
+    -s INITIAL_MEMORY=67108864 \
+    -s EXPORTED_FUNCTIONS='["_main","_wasm_init","_wasm_uci_command"]' \
+    -s EXPORTED_RUNTIME_METHODS='["ccall","cwrap","UTF8ToString"]' \
+    --embed-file nets/fingolfin.nnue@/nets/fingolfin.nnue \
+    --embed-file nets/finarfin.nnue@/nets/finarfin.nnue \
+    --embed-file nets/feanor.nnue@/nets/feanor.nnue
+wasm: OUT := patricia.js
+wasm: $(WASM_SOURCES)
+	$(CXX) $^ $(CXXFLAGS) -o $(OUT)

--- a/engine/src/patricia.cpp
+++ b/engine/src/patricia.cpp
@@ -3,6 +3,177 @@
 #include <memory>
 #include <stdio.h>
 
+#ifdef WASM_BUILD
+#include <emscripten/emscripten.h>
+#include <sstream>
+
+// Global state for WASM
+static Position g_position;
+static std::unique_ptr<ThreadInfo> g_thread_info;
+static bool g_initialized = false;
+
+extern "C" {
+
+// Initialize the engine (called once at startup)
+EMSCRIPTEN_KEEPALIVE
+void wasm_init() {
+    if (!g_initialized) {
+        g_thread_info = std::make_unique<ThreadInfo>();
+        init_LMR();
+        init_bbs();
+        init_nnue_wasm(); // Load NNUE networks from embedded filesystem
+        new_game(*g_thread_info, TT);
+        set_board(g_position, *g_thread_info,
+                  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        g_initialized = true;
+    }
+}
+
+// Process a single UCI command
+EMSCRIPTEN_KEEPALIVE
+void wasm_uci_command(const char* cmd) {
+    if (!g_initialized) {
+        wasm_init();
+    }
+
+    std::string input(cmd);
+    std::istringstream input_stream(input);
+    std::string command;
+    input_stream >> std::skipws >> command;
+
+    if (command == "uci") {
+        printf("id name Patricia 5.0 WASM\n"
+               "id author Adam Kulju\n"
+               "option name Hash type spin default 32 min 1 max 131072\n"
+               "option name MultiPV type spin default 1 min 1 max 255\n"
+               "uciok\n");
+    }
+    else if (command == "isready") {
+        printf("readyok\n");
+    }
+    else if (command == "ucinewgame") {
+        new_game(*g_thread_info, TT);
+        set_board(g_position, *g_thread_info,
+                  "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+    }
+    else if (command == "position") {
+        g_thread_info->game_ply = 6;
+        std::string setup;
+        input_stream >> setup;
+        if (setup == "fen") {
+            std::string fen;
+            for (int i = 0; i < 6; i++) {
+                std::string substr;
+                input_stream >> substr;
+                fen += substr + " ";
+            }
+            set_board(g_position, *g_thread_info, fen);
+        } else {
+            set_board(g_position, *g_thread_info,
+                      "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1");
+        }
+        calculate(g_position);
+
+        std::string has_moves;
+        if (input_stream >> has_moves) {
+            std::string moves;
+            while (input_stream >> moves) {
+                Move move = uci_to_internal(g_position, moves);
+                ss_push(g_position, *g_thread_info, move);
+                make_move(g_position, move);
+            }
+        }
+    }
+    else if (command == "go") {
+        g_thread_info->start_time = std::chrono::steady_clock::now();
+        g_thread_info->max_nodes_searched = UINT64_MAX / 2;
+        g_thread_info->max_iter_depth = MaxSearchDepth;
+
+        int color = g_position.color, time = INT32_MAX, increment = 0;
+        std::string token;
+        while (input_stream >> token) {
+            if (token == "infinite") {
+                ;
+            } else if (token == "wtime" && color == Colors::White) {
+                input_stream >> time;
+            } else if (token == "btime" && color == Colors::Black) {
+                input_stream >> time;
+            } else if (token == "winc" && color == Colors::White) {
+                input_stream >> increment;
+            } else if (token == "binc" && color == Colors::Black) {
+                input_stream >> increment;
+            } else if (token == "nodes") {
+                uint64_t nodes;
+                input_stream >> nodes;
+                g_thread_info->max_nodes_searched = nodes;
+            } else if (token == "depth") {
+                int depth;
+                input_stream >> depth;
+                g_thread_info->max_iter_depth = depth;
+            } else if (token == "movetime") {
+                int movetime;
+                input_stream >> movetime;
+                g_thread_info->max_time = movetime;
+                g_thread_info->opt_time = INT32_MAX / 2;
+                goto run;
+            }
+        }
+
+        time = std::max(2, time - 50);
+        g_thread_info->max_time = time * 8 / 10;
+        g_thread_info->opt_time = (time / 20 + increment) * 6 / 10;
+
+    run:
+        thread_data.stop = false;
+        search_position(g_position, *g_thread_info, TT);
+    }
+    else if (command == "stop") {
+        thread_data.stop = true;
+    }
+    else if (command == "setoption") {
+        std::string name_token;
+        int value;
+        input_stream >> name_token; // "name"
+        std::string name;
+        input_stream >> name;
+        input_stream >> name_token; // "value"
+        input_stream >> value;
+
+        if (name == "Hash") {
+            resize_TT(value);
+        }
+        else if (name == "MultiPV") {
+            g_thread_info->multipv = value;
+        }
+    }
+    else if (command == "perft") {
+        int depth;
+        input_stream >> depth;
+        auto start_time = std::chrono::steady_clock::now();
+        uint64_t nodes = perft(depth, g_position, true, *g_thread_info);
+        printf("%" PRIu64 " nodes %" PRIu64 " nps\n", nodes,
+               (uint64_t)(nodes * 1000 /
+                          (std::max((int64_t)1, time_elapsed(start_time)))));
+    }
+    else if (command == "bench") {
+        bench(g_position, *g_thread_info);
+    }
+
+    fflush(stdout);
+}
+
+} // extern "C"
+
+int main(int argc, char *argv[]) {
+    // For WASM, main just initializes and returns
+    // Commands are processed via wasm_uci_command
+    wasm_init();
+    return 0;
+}
+
+#else
+// Native build
+
 int main(int argc, char *argv[]) {
   Position position;
   std::unique_ptr<ThreadInfo> thread_info = std::make_unique<ThreadInfo>();
@@ -25,3 +196,5 @@ int main(int argc, char *argv[]) {
   uci(*thread_info, position);
   return 0;
 }
+
+#endif // WASM_BUILD

--- a/engine/src/position.h
+++ b/engine/src/position.h
@@ -746,7 +746,9 @@ void make_move(Position &position, Move move) { // Perform a move on the board.
   position.zobrist_key = temp_hash;
   position.pawn_key = temp_pawns;
 
+#ifndef WASM_BUILD
   __builtin_prefetch(&TT[hash_to_idx(temp_hash)]);
+#endif
 }
 
 bool is_pseudo_legal(const Position &position, Move move, uint64_t checkers) {

--- a/engine/test_wasm.html
+++ b/engine/test_wasm.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>Patricia Chess Engine - WASM Test</title>
+    <style>
+        body { font-family: monospace; padding: 20px; }
+        #output {
+            background: #1a1a1a;
+            color: #00ff00;
+            padding: 20px;
+            height: 400px;
+            overflow-y: auto;
+            white-space: pre-wrap;
+        }
+        #input { width: 80%; font-family: monospace; padding: 10px; }
+        button { padding: 10px 20px; margin-left: 10px; }
+        h1 { color: #333; }
+    </style>
+</head>
+<body>
+    <h1>Patricia Chess Engine (WASM)</h1>
+    <p>Enter UCI commands below:</p>
+    <div>
+        <input type="text" id="input" placeholder="Enter UCI command (e.g., 'uci', 'isready', 'go depth 5')">
+        <button onclick="sendCommand()">Send</button>
+    </div>
+    <h3>Output:</h3>
+    <div id="output"></div>
+
+    <script src="patricia.js"></script>
+    <script>
+        let engine = null;
+        const output = document.getElementById('output');
+        const input = document.getElementById('input');
+
+        // Capture stdout
+        const originalPrint = console.log;
+
+        function log(text) {
+            output.textContent += text + '\n';
+            output.scrollTop = output.scrollHeight;
+        }
+
+        // Initialize the engine
+        Patricia({
+            print: function(text) {
+                log(text);
+            },
+            printErr: function(text) {
+                log('[ERROR] ' + text);
+            }
+        }).then(function(Module) {
+            engine = Module;
+            log('Patricia WASM loaded successfully!');
+            log('Type "uci" to start, or "go depth 5" to search.');
+            log('');
+        }).catch(function(err) {
+            log('Failed to load Patricia: ' + err);
+        });
+
+        function sendCommand() {
+            if (!engine) {
+                log('Engine not loaded yet!');
+                return;
+            }
+            const cmd = input.value.trim();
+            if (cmd) {
+                log('> ' + cmd);
+                engine.ccall('wasm_uci_command', null, ['string'], [cmd]);
+                input.value = '';
+            }
+        }
+
+        // Allow Enter key to send command
+        input.addEventListener('keypress', function(e) {
+            if (e.key === 'Enter') {
+                sendCommand();
+            }
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `wasm` target to Makefile using Emscripten
- Enable Patricia to run in web browsers via WebAssembly
- Single-threaded build with NNUE networks embedded in the WASM binary

## Changes
- Guard threading code (Barrier, std::thread) with `#ifndef WASM_BUILD`
- Replace 128-bit integer with portable 64-bit multiply-high for hash indexing
- Disable `__builtin_prefetch` for WASM
- Add WASM-compatible NNUE loading from embedded filesystem (replaces incbin.h)
- Disable Syzygy tablebase support in WASM build
- Add `wasm_init()` and `wasm_uci_command()` exported functions for JavaScript
- Add test HTML page and README documentation

## Build
```bash
cd engine
source /path/to/emsdk/emsdk_env.sh
make wasm
```

## Usage
```javascript
Patricia().then(Module => {
    Module.ccall('wasm_uci_command', null, ['string'], ['uci']);
    Module.ccall('wasm_uci_command', null, ['string'], ['position startpos']);
    Module.ccall('wasm_uci_command', null, ['string'], ['go depth 10']);
});
```

## Test plan
- [x] WASM build compiles successfully
- [x] Native build still works
- [x] UCI commands work in browser (uci, isready, position, go)
- [x] Search returns valid moves

🤖 Generated with [Claude Code](https://claude.ai/code)