### PR TITLE
Score diff tm

### DIFF
--- a/engine/src/params.h
+++ b/engine/src/params.h
@@ -85,6 +85,9 @@ TUNE_PARAM(AspStartWindow, 20, 10, 30);
 TUNE_PARAM(NodeTmFactor1, 149, 100, 200);
 TUNE_PARAM(NodeTmFactor2, 177, 125, 225);
 TUNE_PARAM(BmFactor1, 152, 100, 200);
+TUNE_PARAM(ScoreDropDiv, 140, 80, 300);
+TUNE_PARAM(ScoreDropMin, 90, 70, 100);
+TUNE_PARAM(ScoreDropMax, 118, 100, 140);
 
 #undef TUNE_PARAM
 

--- a/engine/src/params.h
+++ b/engine/src/params.h
@@ -85,7 +85,7 @@ TUNE_PARAM(AspStartWindow, 20, 10, 30);
 TUNE_PARAM(NodeTmFactor1, 149, 100, 200);
 TUNE_PARAM(NodeTmFactor2, 177, 125, 225);
 TUNE_PARAM(BmFactor1, 152, 100, 200);
-TUNE_PARAM(ScoreDropDiv, 140, 80, 300);
+TUNE_PARAM(ScoreDropDiv, 540, 250, 850);
 TUNE_PARAM(ScoreDropMin, 90, 70, 100);
 TUNE_PARAM(ScoreDropMax, 118, 100, 140);
 

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -1178,7 +1178,11 @@ void iterative_deepen(
   Move prev_best = MoveNone;
   int alpha = ScoreNone, beta = -ScoreNone;
   int bm_stability = 0;
-  int prev_score = ScoreNone;
+
+  // Short rolling window of recently completed iteration scores, used to
+  // smooth out single-iteration noise in the score-drop time factor.
+  std::array<int, 3> score_hist{};
+  int score_hist_count = 0;
 
   for (int depth = 1; depth <= thread_info.max_iter_depth; depth++) {
 
@@ -1315,13 +1319,24 @@ void iterative_deepen(
             bm_stability = 0;
           }
 
+          int avg_prev_score = score;
+          if (score_hist_count > 0) {
+            int n = std::min<int>(score_hist_count, score_hist.size());
+            int sum = 0;
+            for (int i = 0; i < n; i++) {
+              sum += score_hist[i];
+            }
+            avg_prev_score = sum / n;
+          }
+
           adjust_soft_limit(
               thread_info,
               find_root_move(thread_info, thread_info.best_moves[0])->nodes,
-              bm_stability, score, prev_score == ScoreNone ? score : prev_score);
+              bm_stability, score, avg_prev_score);
         }
 
-        prev_score = score;
+        score_hist[score_hist_count % score_hist.size()] = score;
+        score_hist_count++;
 
         if (depth >= 6 && total_mat(position) >= PhaseBound){
           if (thread_info.best_scores[0] < -20){

--- a/engine/src/search.h
+++ b/engine/src/search.h
@@ -1178,6 +1178,7 @@ void iterative_deepen(
   Move prev_best = MoveNone;
   int alpha = ScoreNone, beta = -ScoreNone;
   int bm_stability = 0;
+  int prev_score = ScoreNone;
 
   for (int depth = 1; depth <= thread_info.max_iter_depth; depth++) {
 
@@ -1317,8 +1318,10 @@ void iterative_deepen(
           adjust_soft_limit(
               thread_info,
               find_root_move(thread_info, thread_info.best_moves[0])->nodes,
-              bm_stability);
+              bm_stability, score, prev_score == ScoreNone ? score : prev_score);
         }
+
+        prev_score = score;
 
         if (depth >= 6 && total_mat(position) >= PhaseBound){
           if (thread_info.best_scores[0] < -20){

--- a/engine/src/tm.h
+++ b/engine/src/tm.h
@@ -1,12 +1,21 @@
 #pragma once
 #include "defs.h"
 #include "utils.h"
+#include <algorithm>
 
-void adjust_soft_limit(ThreadInfo &thread_info, uint64_t best_move_nodes, int bm_stability) {
+void adjust_soft_limit(ThreadInfo &thread_info, uint64_t best_move_nodes,
+                        int bm_stability, int score, int prev_score) {
   double fract = (double)best_move_nodes / thread_info.nodes;
   double factor = (NodeTmFactor1 / 100.0f - fract) * NodeTmFactor2 / 100.0f;
   double bm_factor = BmFactor1 / 100.0f - (bm_stability * 0.06);
 
-  thread_info.opt_time = std::min<uint32_t>(thread_info.original_opt * factor * bm_factor,
-                                            thread_info.max_time);
+  // If the score dropped since the last iteration, the position likely got
+  // more critical, so allocate extra time; if it rose, allocate less.
+  double score_factor =
+      std::clamp(1.0 + (prev_score - score) / (double)ScoreDropDiv,
+                 ScoreDropMin / 100.0, ScoreDropMax / 100.0);
+
+  thread_info.opt_time = std::min<uint32_t>(
+      thread_info.original_opt * factor * bm_factor * score_factor,
+      thread_info.max_time);
 }


### PR DESCRIPTION
Elo   | 1.56 +- 1.26 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 3.00]
Games | N: 84880 W: 17144 L: 16762 D: 50974
Penta | [870, 8531, 23368, 8689, 982]
https://chess.swehosting.se/test/14286/