### PR TITLE
add move overhead option

### DIFF
--- a/engine/src/uci.h
+++ b/engine/src/uci.h
@@ -211,6 +211,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
              "option name SyzygyPath type string default null\n"
              "option name MultiPV type spin default 1 min 1 max 255\n"
              "option name Skill_Level type spin default 21 min 1 max 21\n"
+             "option name Move_Overhead type spin default 50 min 0 max 5000\n"
              "option name UCI_Chess960 type check default false\n");
 
       /*for (auto &param : params) {
@@ -312,6 +313,10 @@ void uci(ThreadInfo &thread_info, Position &position) {
 
       else if (name == "MultiPV") {
         thread_info.multipv = value;
+      }
+
+      else if (name == "Move_Overhead") {
+        thread_data.move_overhead = value;
       }
 
       else {
@@ -422,7 +427,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
         } else if (token == "movetime") {
           int time;
           input_stream >> time;
-          thread_info.max_time = time;
+          thread_info.max_time = std::max(2, time - thread_data.move_overhead);
           thread_info.opt_time = INT32_MAX / 2;
           goto run;
         }
@@ -430,7 +435,7 @@ void uci(ThreadInfo &thread_info, Position &position) {
 
       // Calculate time allotted to search
 
-      time = std::max(2, time - 50);
+      time = std::max(2, time - thread_data.move_overhead);
       thread_info.max_time = time * 8 / 10;
       thread_info.opt_time = (time / 20 + increment) * 6 / 10;
 

--- a/engine/src/utils.h
+++ b/engine/src/utils.h
@@ -88,6 +88,7 @@ struct ThreadData {
   std::atomic<bool> stop = true;
   std::atomic<bool> terminate = false;
   bool is_frc = false;
+  int move_overhead = 50;
 };
 
 ThreadData thread_data;


### PR DESCRIPTION
Bench: 3015693

Elo   | 3.09 +- 2.96 (95%)
SPRT  | 8.0+0.08s Threads=1 Hash=16MB
LLR   | 3.02 (-2.94, 2.94) [-3.00, 0.00]
Games | N: 17772 W: 3790 L: 3632 D: 10350
Penta | [235, 1915, 4474, 1981, 281]
https://chess.swehosting.se/test/14295/